### PR TITLE
Missing option for `cosmiconfig`

### DIFF
--- a/lib/params.js
+++ b/lib/params.js
@@ -87,7 +87,8 @@ function params (from) {
   // same as the options in stylelint
   var opts = {
     argv: false,
-    rcExtensions: true
+    rcExtensions: true,
+    cwd: wd
   }
   return cosmiconfig('stylelint', opts).then(function (stylelint) {
     var params = {}


### PR DESCRIPTION
It seems to me that is need here :construction_worker: 