### PR TITLE
Add support for groups in `declaration-block-properties-order`

### DIFF
--- a/lib/formatOrder.js
+++ b/lib/formatOrder.js
@@ -6,8 +6,21 @@ function formatOrder(root, params) {
     return;
   }
 
+  // sort order can contain groups, so it needs to be flat for postcss-sorting
+  var flattenedSortOrder = [];
+
+  sortOrder.forEach(function(item) {
+    if (typeof item === 'string') {
+      flattenedSortOrder.push(item);
+    } else if (typeof item === 'object' && Array.isArray(item.properties)) {
+      item.properties.forEach(function(prop) {
+        flattenedSortOrder.push(prop);
+      });
+    }
+  });
+
   var sort = sorting({
-    'sort-order': sortOrder
+    'sort-order': flattenedSortOrder
   });
 
   sort(root);

--- a/test/stylelint/declaration-block-properties-order-groups/.stylelintrc
+++ b/test/stylelint/declaration-block-properties-order-groups/.stylelintrc
@@ -1,0 +1,25 @@
+{
+  "rules": {
+    "declaration-block-properties-order": [
+      {
+        "properties": [
+          "font-size",
+          "font-weight"
+        ]
+      },
+      "display",
+      {
+        "properties": [
+        ]
+      },
+      "width",
+      {
+        "object-without-properties-property": true
+      },
+      "height",
+      "color",
+      "background",
+      "opacity"
+    ]
+  }
+}

--- a/test/stylelint/declaration-block-properties-order-groups/declaration-block-properties-order-groups.css
+++ b/test/stylelint/declaration-block-properties-order-groups/declaration-block-properties-order-groups.css
@@ -1,0 +1,10 @@
+a {
+  height: 20px;
+  font-size: 18px;
+  color: #000;
+  opacity: .8;
+  width: 10px;
+  display: block;
+  font-weight: normal;
+  background: #fff;
+}

--- a/test/stylelint/declaration-block-properties-order-groups/declaration-block-properties-order-groups.out.css
+++ b/test/stylelint/declaration-block-properties-order-groups/declaration-block-properties-order-groups.out.css
@@ -1,0 +1,10 @@
+a {
+  font-size: 18px;
+  font-weight: normal;
+  display: block;
+  width: 10px;
+  height: 20px;
+  color: #000;
+  background: #fff;
+  opacity: .8;
+}


### PR DESCRIPTION
Add support for groups in stylelint config:

```json
{
  "rules": {
    "declaration-block-properties-order": [
      {
        "properties": [
          "font-size",
          "font-weight"
        ]
      },
      "display",
      "width",
      "height",
      "color",
      "background",
      "opacity"
    ]
  }
}
```

Also it fixes #165.