### PR TITLE
Added --list cli option to allow multiple in-place cli inputs

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,6 +17,7 @@ var argv = minimist(process.argv.slice(2), {
     h: 'help',
     v: 'version',
     d: 'diff',
+    l: 'list',
     R: 'recursive',
     c: 'config'
   }
@@ -37,6 +38,7 @@ if (argv.h) {
   console.log('Options:')
   console.log('')
   console.log('  -d, --diff        output diff against original file')
+  console.log('  -l, --list        format list of space seperated files in place')
   console.log('  -R, --recursive   format files recursively')
   console.log('  -c, --config      path to a specific configuration file (JSON, YAML, or CommonJS)')
   console.log('  -v, --version     output the version number')
@@ -50,7 +52,10 @@ if (argv.c) {
   options.config = argv.c
 }
 
-if (argv._[0]) {
+if (argv.l) {
+  var files = [argv.l].concat(argv._)
+  processMultipleFiles(files)
+} else if (argv._[0]) {
   var input = argv._[0]
   var output = argv._[1] || argv._[0]
 
@@ -77,34 +82,39 @@ if (argv._[0]) {
   var recursive = require('recursive-readdir')
 
   recursive(argv.R, function (err, files) {
-    files.forEach(function (file) {
-      var fullPath = path.resolve(process.cwd(), file)
-      if (!isCss(fullPath)) {
-        return
-      }
-
-      var css = fs.readFileSync(fullPath, 'utf-8')
-
-      postcss([stylefmt(options)])
-        .process(css, { syntax: scss })
-        .then(function (result) {
-          var formatted = result.css
-          if (css !== formatted) {
-            fs.writeFile(fullPath, formatted, function (err) {
-              if (err) {
-                throw err
-              }
-            })
-          }
-        })
-      })
-    })
+    processMultipleFiles(files)
+  })
 } else {
   stdin(function (css) {
     postcss([stylefmt(options)])
       .process(css, { syntax: scss })
       .then(function (result) {
         process.stdout.write(result.css)
+      })
+  })
+}
+
+
+function processMultipleFiles (files) {
+  files.forEach(function (file) {
+    var fullPath = path.resolve(process.cwd(), file)
+    if (!isCss(fullPath)) {
+      return
+    }
+
+    var css = fs.readFileSync(fullPath, 'utf-8')
+
+    postcss([stylefmt(options)])
+      .process(css, { syntax: scss })
+      .then(function (result) {
+        var formatted = result.css
+        if (css !== formatted) {
+          fs.writeFile(fullPath, formatted, function (err) {
+            if (err) {
+              throw err
+            }
+          })
+        }
       })
   })
 }


### PR DESCRIPTION
For CI and pre-commit hooks, it would be useful to be able to pass a list of files to format in-place to the cli.

This PR adds this option to the cli (--list/-l could arguably be better named, lmk!)

More context: https://github.com/pre-commit/pre-commit/issues/394