### PR TITLE
Fix silent failure of format-order when config object is used

### DIFF
--- a/lib/formatOrder.js
+++ b/lib/formatOrder.js
@@ -6,6 +6,12 @@ function formatOrder(root, params) {
     return;
   }
 
+  // If the sylelint array configuration style is used, the sort order is the
+  // first item in the list.
+  if (Array.isArray(sortOrder[0])) {
+    sortOrder = sortOrder[0];
+  }
+
   // sort order can contain groups, so it needs to be flat for postcss-sorting
   var flattenedSortOrder = [];
 

--- a/test/stylelint/declaration-block-properties-order-severity/.stylelintrc
+++ b/test/stylelint/declaration-block-properties-order-severity/.stylelintrc
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "declaration-block-properties-order": [[
+      "@atrule",
+      "display",
+      "width",
+      "height",
+      "color",
+      "background"
+    ], {
+      "severity": "warning"
+    }]
+  }
+}

--- a/test/stylelint/declaration-block-properties-order-severity/declaration-block-properties-order-severity.css
+++ b/test/stylelint/declaration-block-properties-order-severity/declaration-block-properties-order-severity.css
@@ -1,0 +1,8 @@
+a {
+  height: 20px;
+  color: #000;
+  @include "foo";
+  width: 10px;
+  display: block;
+  background: #fff;
+}

--- a/test/stylelint/declaration-block-properties-order-severity/declaration-block-properties-order-severity.out.css
+++ b/test/stylelint/declaration-block-properties-order-severity/declaration-block-properties-order-severity.out.css
@@ -1,0 +1,8 @@
+a {
+  @include "foo";
+  display: block;
+  width: 10px;
+  height: 20px;
+  color: #000;
+  background: #fff;
+}


### PR DESCRIPTION
Right now using the `[["propertyOne", "propertyTwo"], {"severity": "warning"}]` format for `declaration-block-properties-order` results in silent failure and leaves the order unchanged. This should fix that case.

I did my best to do everything in the existing style but let me know if you would like anything changed to fit better and I'm happy to do it.