### PR TITLE
fix block-opening-brace-space-after for include at-rule containing ch…

### DIFF
--- a/lib/formatAtRules.js
+++ b/lib/formatAtRules.js
@@ -138,7 +138,7 @@ function formatAtRules (root, params) {
         }
       }
 
-      if (!hasRules(atrule) && !hasDecls(atrule)) {
+      if (!hasBlock(atrule) && !hasRules(atrule) && !hasDecls(atrule)) {
         atrule.raws.between = ''
       }
     }


### PR DESCRIPTION
…ild at-rules

I'm using "include" @-rule with postcss, stylefmt, stylelint, and stylelint-config-standard. The following block represents the original SCSS source.

```
@include breakpoint(tablet) {
  @include size(16px);
}
```

The space before the brace ("{") gets removed at the stylefmt output, as follows:

```
@include breakpoint(tablet){
  @include size(16px);
}
```

After struggling a lot, and being inspired by issue #117, I was able to produce a solution by adding the !hasBlock(atrule) check at the highlighted section. In this case, an include at-rule containing only child at-rule(s) are not considered to be empty, and the space after the opening brace has been placed/formatted correctly.