### PR TITLE
Exclude files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+node_modules
+test
+.editorconfig
+.eslintrc.json
+.travis.yml
+CHANGELOG.md


### PR DESCRIPTION
... via `.npmignore`

`npm pack` results:

* With ignore file 15K, or 15855 Bytes
* Without ignore file 37K, or 37604 Bytes

Fixes #229 