### PR TITLE
Add support for glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## HEAD
+
+- Added: globs support for `--list` option in CLI. #223
+- Deleted: `--recursive` option in CLI, please use the `stylefmt --list /readdir/**/*.css` instead.
+
 ## v4.4.0
 
 - Fixed [Same issue in stylelint #218](https://github.com/stylelint/stylelint/issues/1881) use `stylelint` to load configuration file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: globs support for `--list` option in CLI. #223
 - Deleted: `--recursive` option in CLI, please use the `stylefmt --list /readdir/**/*.css` instead.
+- Fixed: `--diff` option in CLI can use with `--list`.
 
 ## v4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added: globs support for `--list` option in CLI. #223
 - Deleted: `--recursive` option in CLI, please use the `stylefmt --list /readdir/**/*.css` instead.
-- Fixed: `--diff` option in CLI can use with `--list`.
+- Fixed: options `--diff` and `--list` in CLI can be used together.
 
 ## v4.4.0
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Usage: stylefmt [options] input-file [output-file]
 Options:
 
   -d, --diff             output diff against original file
-  -l, --list             Format list of space seperated globs in place
+  -l, --list             Format list of space seperated files(globs) in place
   -c, --config           path to a specific configuration file (JSON, YAML, or CommonJS)
   -b, --config-basedir   path to the directory that relative paths defining "extends"
   -V, --versions         output the version number

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Usage: stylefmt [options] input-file [output-file]
 Options:
 
   -d, --diff             output diff against original file
-  -R, --recursive        format files recursively
+  -l, --list             Format list of space seperated globs in place
   -c, --config           path to a specific configuration file (JSON, YAML, or CommonJS)
   -b, --config-basedir   path to the directory that relative paths defining "extends"
   -V, --versions         output the version number

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,7 +39,7 @@ if (argv.h) {
   console.log('Options:')
   console.log('')
   console.log('  -d, --diff             output diff against original file')
-  console.log('  -l, --list             format list of space seperated globs in place')
+  console.log('  -l, --list             Format list of space seperated globs in place')
   console.log('  -c, --config           path to a specific configuration file (JSON, YAML, or CommonJS)')
   console.log('  -b, --config-basedir   path to the directory that relative paths defining "extends"')
   console.log('  -v, --version          output the version number')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,7 +37,7 @@ if (argv.h) {
   console.log('Options:')
   console.log('')
   console.log('  -d, --diff             output diff against original file')
-  console.log('  -l, --list             Format list of space seperated globs in place')
+  console.log('  -l, --list             Format list of space seperated files(globs) in place')
   console.log('  -c, --config           path to a specific configuration file (JSON, YAML, or CommonJS)')
   console.log('  -b, --config-basedir   path to the directory that relative paths defining "extends"')
   console.log('  -v, --version          output the version number')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,8 +39,7 @@ if (argv.h) {
   console.log('Options:')
   console.log('')
   console.log('  -d, --diff             output diff against original file')
-  console.log('  -l, --list             format list of space seperated files in place')
-  console.log('  -R, --recursive        format files recursively')
+  console.log('  -l, --list             format list of space seperated globs in place')
   console.log('  -c, --config           path to a specific configuration file (JSON, YAML, or CommonJS)')
   console.log('  -b, --config-basedir   path to the directory that relative paths defining "extends"')
   console.log('  -v, --version          output the version number')
@@ -61,8 +60,8 @@ if (argv.b) {
 }
 
 if (argv.l) {
-  var files = [argv.l].concat(argv._)
-  processMultipleFiles(files)
+  var globby = require('globby')
+  globby([argv.l].concat(argv._)).then(processMultipleFiles)
 } else if (argv._[0]) {
   var input = path.resolve(process.cwd(), argv._[0])
   var output = argv._[1] || argv._[0]
@@ -89,12 +88,6 @@ if (argv.l) {
         }
       }
     })
-} else if (argv.R) {
-  var recursive = require('recursive-readdir')
-
-  recursive(argv.R, function (err, files) {
-    processMultipleFiles(files)
-  })
 } else {
   stdin(function (css) {
     postcss([stylefmt(options)])

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -129,7 +129,7 @@ function processMultipleFiles (files) {
       })
   })).then(function (messages) {
     if (argv.d) {
-      console.log(messages.join('\n'))
+      console.log(messages.join('\n\n'))
     } else {
       messages = messages.filter(function (file){
         return file
@@ -151,6 +151,10 @@ function isCss (filePath) {
 
 
 function handleDiff (file, original, formatted) {
+  if (original === formatted) {
+    return file + '\nThere is no difference with the original file.'
+  }
+
   var chalk = require('chalk')
   if (chalk.supportsColor) {
     var JsDiff = require('diff')

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -100,7 +100,7 @@ if (argv.l) {
 function processMultipleFiles (files) {
   files = files.filter(isCss).sort()
   if(!files.length){
-    console.error("Files glob patterns specified did not match any css files")
+    console.error("Files glob patterns specified did not match any css files.")
     return
   }
 
@@ -124,10 +124,23 @@ function processMultipleFiles (files) {
               throw err
             }
           })
+          return file
         }
       })
   })).then(function (messages) {
-    console.log(messages.join('\n'))
+    if (argv.d) {
+      console.log(messages.join('\n'))
+    } else {
+      messages = messages.filter(function (file){
+        return file
+      })
+      if(messages.length){
+        messages = messages.join(', ') + '\n\n' + messages.length
+      } else {
+        messages = 'No'
+      }
+      console.log(messages + ' files are formatted.')
+    }
   })
 }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -97,7 +97,7 @@ if (argv.l) {
 
 
 function processMultipleFiles (files) {
-  files = files.filter(isCss)
+  files = files.filter(isCss).sort()
   if(!files.length){
     console.error("Files glob patterns specified did not match any css files")
     return

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "postcss-scss": "^0.4.0",
     "postcss-sorting": "^1.7.0",
     "postcss-value-parser": "^3.3.0",
-    "recursive-readdir": "^2.1.0",
     "stdin": "0.0.1",
     "stylelint": "^7.5.0",
     "tmp": "0.0.30"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "each-series": "^1.0.0",
-    "eslint": "^3.9.1",
+    "eslint": "^3.10.1",
     "faucet": "0.0.1",
     "klaw": "^1.3.1",
     "tape": "^4.6.2"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "css-color-list": "0.0.1",
     "editorconfig": "^0.13.2",
+    "globby": "^6.1.0",
     "minimist": "^1.2.0",
     "postcss": "^5.2.5",
     "postcss-scss": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "author": "Masaaki Morishita",
   "license": "MIT",
   "dependencies": {
+    "chalk": "^1.1.3",
     "css-color-list": "0.0.1",
+    "diff": "^3.0.1",
     "editorconfig": "^0.13.2",
     "globby": "^6.1.0",
     "minimist": "^1.2.0",
@@ -39,8 +41,7 @@
     "postcss-sorting": "^1.7.0",
     "postcss-value-parser": "^3.3.0",
     "stdin": "0.0.1",
-    "stylelint": "^7.5.0",
-    "tmp": "0.0.30"
+    "stylelint": "^7.5.0"
   },
   "devDependencies": {
     "each-series": "^1.0.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -98,7 +98,7 @@ tape('cli globs option', function (t) {
       t.end(err)
       return
     }
-    t.equal(output.trim(), 'test/recursive/bar.css\n.bar {\n  color: red;\n}\n\ntest/recursive/foo.css\n.foo {\n  padding: 10px;\n}\n\ntest/recursive/foo/foo.css\n.foo {\n  padding: 10px;\n}')
+    t.equal(output.trim(), 'test/recursive/bar.css\nThere is no difference with the original file.\n\ntest/recursive/foo.css\nThere is no difference with the original file.\n\ntest/recursive/foo/foo.css\nThere is no difference with the original file.')
     t.end()
   })
 })

--- a/test/cli.js
+++ b/test/cli.js
@@ -3,7 +3,6 @@ var path = require('path')
 var spawn = require('child_process').spawn
 
 var tape = require('tape')
-var chalk = require('chalk')
 
 tape('cli stdin', function (t) {
   t.plan(1)
@@ -60,6 +59,38 @@ tape('cli output file option', function (t) {
   })
 })
 
+tape('cli diff option', function (t) {
+  t.plan(1)
+
+  var cssFile = fixturesPath('at-media/at-media.css')
+
+  spawnStylefmt([cssFile, '--diff'], null, function (err, output) {
+    if (err) {
+      t.end(err)
+      return
+    }
+
+    t.equal(output.trim(), cssFile + '\n' + readFixture('at-media/at-media.out.css').trim())
+    t.end()
+  })
+})
+
+tape('cli stdin with diff option', function (t) {
+  t.plan(1)
+
+  var cssFile = fixturesPath('at-media/at-media.css')
+
+  spawnStylefmt(['--diff'], fs.readFileSync(cssFile, 'utf-8'), function (err, output) {
+    if (err) {
+      t.end(err)
+      return
+    }
+
+    t.equal(output.trim(), readFixture('at-media/at-media.out.css').trim())
+    t.end()
+  })
+})
+
 tape('cli globs option', function (t) {
   t.plan(1)
   spawnStylefmt(['--list', 'test/recursive/**/*.css', '--diff'], null, function (err, output) {
@@ -67,7 +98,7 @@ tape('cli globs option', function (t) {
       t.end(err)
       return
     }
-    t.equal(output.trim(), 'test/recursive/bar.css\n.bar {\n  color: red;\n}\n\n\ntest/recursive/foo.css\n.foo {\n  padding: 10px;\n}\n\n\ntest/recursive/foo/foo.css\n.foo {\n  padding: 10px;\n}')
+    t.equal(output.trim(), 'test/recursive/bar.css\n.bar {\n  color: red;\n}\n\ntest/recursive/foo.css\n.foo {\n  padding: 10px;\n}\n\ntest/recursive/foo/foo.css\n.foo {\n  padding: 10px;\n}')
     t.end()
   })
 })
@@ -84,7 +115,7 @@ function readFixture (filename) {
 function spawnStylefmt (options, input, callback) {
   var args = [
     path.join(__dirname, '../bin/cli.js')
-  ].concat(options)
+  ].concat(options).concat('--no-color')
 
   var child = spawn('node', args, {
     stdio: ['pipe', 'pipe', 'pipe']
@@ -105,7 +136,7 @@ function spawnStylefmt (options, input, callback) {
       callback(new Error(error))
       return
     }
-    callback(null, chalk.stripColor(output))
+    callback(null, output)
   })
 
   if (input) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -3,6 +3,7 @@ var path = require('path')
 var spawn = require('child_process').spawn
 
 var tape = require('tape')
+var chalk = require('chalk')
 
 tape('cli stdin', function (t) {
   t.plan(1)
@@ -38,7 +39,7 @@ tape('cli input file option', function (t) {
 tape('cli output file option', function (t) {
   t.plan(1)
   var tempFile = fixturesPath('at-media/at-media.copy.css')
-  spawnStylefmt([fixturesPath('at-media/at-media.css'), tempFile], null, function(err) {
+  spawnStylefmt([fixturesPath('at-media/at-media.css'), tempFile], null, function (err) {
     if (err) {
       t.end(err)
       return
@@ -58,6 +59,19 @@ tape('cli output file option', function (t) {
     t.end()
   })
 })
+
+tape('cli globs option', function (t) {
+  t.plan(1)
+  spawnStylefmt(['--list', 'test/recursive/**/*.css', '--diff'], null, function (err, output) {
+    if (err) {
+      t.end(err)
+      return
+    }
+    t.equal(output.trim(), 'test/recursive/bar.css\n.bar {\n  color: red;\n}\n\n\ntest/recursive/foo.css\n.foo {\n  padding: 10px;\n}\n\n\ntest/recursive/foo/foo.css\n.foo {\n  padding: 10px;\n}')
+    t.end()
+  })
+})
+
 
 function fixturesPath (filename) {
   return path.join(__dirname, 'fixtures', filename)
@@ -91,7 +105,7 @@ function spawnStylefmt (options, input, callback) {
       callback(new Error(error))
       return
     }
-    callback(null, output)
+    callback(null, chalk.stripColor(output))
   })
 
   if (input) {


### PR DESCRIPTION
- [x] Added: globs support for `--list` option in CLI. #223
- [x] Deleted: `--recursive` option in CLI, please use the `stylefmt --list /readdir/**/*.css` instead.
- [x] Fixed: options `--diff` and `--list` in CLI can be used together.
