### PR TITLE
Use external `stylelint` if existence.

### DIFF
--- a/lib/params.js
+++ b/lib/params.js
@@ -1,9 +1,17 @@
 var fs = require('fs')
 var path = require('path')
-var createStylelint = require('stylelint').createLinter
 var editorconfig = require('editorconfig')
 var getProperty = require('./util').getProperty
 var defaultIndentWidth = ' '.repeat(2)
+var stylelint
+
+try {
+  stylelint = process.mainModule.require('stylelint')
+} catch(ex) {
+  //
+}
+
+var createStylelint = stylelint && stylelint.createLinter || require('stylelint').createLinter
 
 function hasScssInDir (wd) {
   var dirs = fs.readdirSync(wd)
@@ -52,11 +60,11 @@ function getIndentationFromStylelintRules (rules) {
 }
 
 function loadConfig (stylelint, file, options) {
-  return stylelint.isPathIgnored(file, options.configFile).then(function (isIgnored) {
+  return stylelint.isPathIgnored(file).then(function (isIgnored) {
     if (isIgnored) {
       return null
     }
-    return stylelint.getConfigForFile(file, options.configFile).then(function (stylelintrc) {
+    return stylelint.getConfigForFile(file).then(function (stylelintrc) {
       return stylelintrc && stylelintrc.config && stylelintrc.config.rules
     })
   }).catch(function (err) {

--- a/package.json
+++ b/package.json
@@ -36,18 +36,18 @@
     "editorconfig": "^0.13.2",
     "globby": "^6.1.0",
     "minimist": "^1.2.0",
-    "postcss": "^5.2.5",
+    "postcss": "^5.2.6",
     "postcss-scss": "^0.4.0",
     "postcss-sorting": "^1.7.0",
     "postcss-value-parser": "^3.3.0",
     "stdin": "0.0.1",
-    "stylelint": "^7.5.0"
+    "stylelint": "^7.6.0"
   },
   "devDependencies": {
     "each-series": "^1.0.0",
-    "eslint": "^3.10.1",
+    "eslint": "^3.10.2",
     "faucet": "0.0.1",
     "klaw": "^1.3.1",
-    "tape": "^4.6.2"
+    "tape": "^4.6.3"
   }
 }


### PR DESCRIPTION
Change:
- Fixed: Use external `stylelint` if exist. For close #237
- Fixed: Remove redundant parameters for `stylelint.getConfigForFile` & `stylelint.isPathIgnored`
- Upgrade dependency
