### PR TITLE
Prevent space between EOL and semicolon for @value

### DIFF
--- a/lib/formatAtRules.js
+++ b/lib/formatAtRules.js
@@ -80,7 +80,7 @@ function formatAtRules (root, params) {
       stylelint: stylelint
     })
 
-    if (atrule.name === 'import' || atrule.name === 'charset') {
+    if (atrule.name === 'import' || atrule.name === 'charset' || atrule.name === 'value') {
       atrule.raws.between = ''
     }
 
@@ -108,10 +108,6 @@ function formatAtRules (root, params) {
         atrule.name === 'error' ) {
       atrule.params = atrule.params.replace(/\s+/g, " ")
       atrule.raws.before = '\n' + indentation
-      atrule.raws.between = ''
-    }
-
-    if (atrule.name === 'value') {
       atrule.raws.between = ''
     }
 

--- a/lib/formatAtRules.js
+++ b/lib/formatAtRules.js
@@ -111,6 +111,10 @@ function formatAtRules (root, params) {
       atrule.raws.between = ''
     }
 
+    if (atrule.name === 'value') {
+      atrule.raws.between = ''
+    }
+
     if (atrule.name === 'warn' || atrule.name === 'error') {
       atrule.params = atrule.params.replace(/("|')\s*/g, '"')
       atrule.params = atrule.params.replace(/\s*("|')/g, '"')

--- a/test/css-modules/value/value.css
+++ b/test/css-modules/value/value.css
@@ -1,0 +1,1 @@
+@value myValue: #fff;

--- a/test/css-modules/value/value.out.css
+++ b/test/css-modules/value/value.out.css
@@ -1,0 +1,1 @@
+@value myValue: #fff;

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,7 @@ var cwd = process.cwd()
 var testBaseDirPaths = [
   path.join(cwd, 'test/fixtures'),
   path.join(cwd, 'test/sass'),
+  path.join(cwd, 'test/css-modules'),
   path.join(cwd, 'test/stylelint')
 ]
 


### PR DESCRIPTION
@value is a valid CSS-module at-rule; ensure we don't do anything funky with spacing

* Added a test fixture for ensuring @values don't get an extra space
* Added fix in `formatAtRules` to account for @value