### PR TITLE
stylelint-order plugin support

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,10 @@ const stylefmt = postcss.plugin('stylefmt', function (options) {
       if(params) {
         formatComments(root, params)
         formatAtRules(root, params)
-        formatOrder(root, params)
         formatRules(root, params)
         formatSassVariables(root, params)
+        // order should be the last to prevent empty line collapse in order rules
+        formatOrder(root, params)
       }
     }).catch(function (err) {
       console.error(err.stack)

--- a/lib/formatOrder.js
+++ b/lib/formatOrder.js
@@ -1,7 +1,50 @@
 var sorting = require('postcss-sorting')
 
 function formatOrder (root, params) {
-  var sortOrder = params.stylelint['declaration-block-properties-order']
+  var sortOrder =
+    processOrderPluginRule(params.stylelint['order/declaration-block-property-groups-structure']) ||
+    processStylelintRule(params.stylelint['declaration-block-properties-order'])
+
+  if (!Array.isArray(sortOrder)) {
+    return
+  }
+
+  var sort = sorting({
+    'order': [
+      'at-rules',
+      'custom-properties',
+      'dollar-variables',
+      'declarations',
+      'rules',
+    ],
+    'properties-order': sortOrder
+  })
+
+  sort(root)
+}
+
+function processOrderPluginRule (sortOrder) {
+  if (!Array.isArray(sortOrder)) {
+    return
+  }
+
+  // If the sylelint array configuration style is used, the sort order is the
+  // first item in the list.
+  if (Array.isArray(sortOrder[0])) {
+    sortOrder = sortOrder[0]
+  }
+
+  return sortOrder.map(function (item) {
+    if (typeof item === 'object' && item.emptyLineBefore === 'always') {
+      // we should change "always" to "true" for postcss-sorting
+      // copy item to prevent side effects
+      return Object.assign({}, item, {emptyLineBefore: true})
+    }
+    return item
+  })
+}
+
+function processStylelintRule (sortOrder) {
   if (!Array.isArray(sortOrder)) {
     return
   }
@@ -25,18 +68,7 @@ function formatOrder (root, params) {
     }
   })
 
-  var sort = sorting({
-    'order': [
-      'at-rules',
-      'custom-properties',
-      'dollar-variables',
-      'declarations',
-      'rules',
-    ],
-    'properties-order': flattenedSortOrder
-  })
-
-  sort(root)
+  return flattenedSortOrder
 }
 
 module.exports = formatOrder

--- a/lib/formatOrder.js
+++ b/lib/formatOrder.js
@@ -9,14 +9,18 @@ function formatOrder (root, params) {
     return
   }
 
+  // stylelint-order rule or default
+  var declarationBlockOrder = params.stylelint['order/declaration-block-order'] || [
+    'at-rules',
+    'custom-properties',
+    'dollar-variables',
+    'declarations',
+    'rules',
+  ]
+  declarationBlockOrder = flattenRule(declarationBlockOrder)
+
   var sort = sorting({
-    'order': [
-      'at-rules',
-      'custom-properties',
-      'dollar-variables',
-      'declarations',
-      'rules',
-    ],
+    'order': declarationBlockOrder,
     'properties-order': sortOrder
   })
 
@@ -28,11 +32,7 @@ function processOrderPluginRule (sortOrder) {
     return
   }
 
-  // If the sylelint array configuration style is used, the sort order is the
-  // first item in the list.
-  if (Array.isArray(sortOrder[0])) {
-    sortOrder = sortOrder[0]
-  }
+  sortOrder = flattenRule(sortOrder)
 
   return sortOrder.map(function (item) {
     if (typeof item === 'object' && item.emptyLineBefore === 'always') {
@@ -49,11 +49,7 @@ function processStylelintRule (sortOrder) {
     return
   }
 
-  // If the sylelint array configuration style is used, the sort order is the
-  // first item in the list.
-  if (Array.isArray(sortOrder[0])) {
-    sortOrder = sortOrder[0]
-  }
+  sortOrder = flattenRule(sortOrder)
 
   // sort order can contain groups, so it needs to be flat for postcss-sorting
   var flattenedSortOrder = []
@@ -69,6 +65,13 @@ function processStylelintRule (sortOrder) {
   })
 
   return flattenedSortOrder
+}
+
+function flattenRule (rule) {
+  if (Array.isArray(rule[0])) {
+    return rule[0]
+  }
+  return rule
 }
 
 module.exports = formatOrder

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "postcss-sorting": "^2.0.1",
     "postcss-value-parser": "^3.3.0",
     "stdin": "0.0.1",
-    "stylelint": "^7.5.0"
+    "stylelint": "^7.5.0",
+    "stylelint-order": "^0.3.0"
   },
   "devDependencies": {
     "each-series": "^1.0.0",

--- a/test/stylelint/order-declaration-block-order/.stylelintrc
+++ b/test/stylelint/order-declaration-block-order/.stylelintrc
@@ -1,0 +1,33 @@
+{
+  "plugins": [
+    "stylelint-order"
+  ],
+
+  "rules": {
+    "order/declaration-block-order": [
+      "custom-properties",
+      "declarations"
+    ],
+    "order/declaration-block-property-groups-structure": [
+      [
+        {
+          "emptyLineBefore": "always",
+          "properties": [
+            "font-size",
+            "line-height"
+          ]
+        },
+        {
+          "emptyLineBefore": "always",
+          "properties": [
+            "position",
+            "top",
+            "right",
+            "bottom",
+            "left"
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/test/stylelint/order-declaration-block-order/order-declaration-block-order.css
+++ b/test/stylelint/order-declaration-block-order/order-declaration-block-order.css
@@ -1,0 +1,8 @@
+body {
+  line-height: 10px;
+  font-size: 13px;
+  position: absolute;
+  left: 10px;
+  top: 5px;
+  --text-normal: #000;
+}

--- a/test/stylelint/order-declaration-block-order/order-declaration-block-order.out.css
+++ b/test/stylelint/order-declaration-block-order/order-declaration-block-order.out.css
@@ -1,0 +1,9 @@
+body {
+  --text-normal: #000;
+  font-size: 13px;
+  line-height: 10px;
+
+  position: absolute;
+  top: 5px;
+  left: 10px;
+}

--- a/test/stylelint/order-declaration-block-property-groups-structure/.stylelintrc
+++ b/test/stylelint/order-declaration-block-property-groups-structure/.stylelintrc
@@ -1,0 +1,29 @@
+{
+  "plugins": [
+    "stylelint-order"
+  ],
+
+  "rules": {
+    "order/declaration-block-property-groups-structure": [
+      [
+        {
+          "emptyLineBefore": "always",
+          "properties": [
+            "font-size",
+            "line-height"
+          ]
+        },
+        {
+          "emptyLineBefore": "always",
+          "properties": [
+            "position",
+            "top",
+            "right",
+            "bottom",
+            "left"
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/test/stylelint/order-declaration-block-property-groups-structure/order-declaration-block-property-groups-structure.css
+++ b/test/stylelint/order-declaration-block-property-groups-structure/order-declaration-block-property-groups-structure.css
@@ -1,0 +1,7 @@
+body {
+  line-height: 10px;
+  font-size: 13px;
+  position: absolute;
+  left: 10px;
+  top: 5px;
+}

--- a/test/stylelint/order-declaration-block-property-groups-structure/order-declaration-block-property-groups-structure.out.css
+++ b/test/stylelint/order-declaration-block-property-groups-structure/order-declaration-block-property-groups-structure.out.css
@@ -1,0 +1,8 @@
+body {
+  font-size: 13px;
+  line-height: 10px;
+
+  position: absolute;
+  top: 5px;
+  left: 10px;
+}


### PR DESCRIPTION
Since "declaration-block-properties-order" rule is depracated I've updated formatOrder function to support both rules.