### PR TITLE
add support for declaration-empty-line-before

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ stylefmt supports the following stylelint rules:
 - [declaration-block-properties-order](https://github.com/stylelint/stylelint/tree/master/lib/rules/declaration-block-properties-order)
 - [declaration-colon-space-after](https://github.com/stylelint/stylelint/tree/master/lib/rules/declaration-colon-space-after)
 - [declaration-colon-space-before](https://github.com/stylelint/stylelint/tree/master/lib/rules/declaration-colon-space-before)
+- [declaration-empty-line-before](https://github.com/stylelint/stylelint/tree/master/lib/rules/declaration-empty-line-before)
 - [indentation](https://github.com/stylelint/stylelint/tree/master/lib/rules/indentation)
 - [length-zero-no-unit](https://github.com/stylelint/stylelint/tree/master/lib/rules/length-zero-no-unit)
 - [number-leading-zero](https://github.com/stylelint/stylelint/tree/master/lib/rules/number-leading-zero)

--- a/lib/formatDecls.js
+++ b/lib/formatDecls.js
@@ -1,16 +1,20 @@
 var formatValues = require('./formatValues')
 var hasDecls = require('./hasDecls')
-var getProperty =  require('./util').getProperty
+var hasEmptyLine = require('stylelint/lib/utils/hasEmptyLine')
+var isStandardSyntaxDeclaration = require('stylelint/lib/utils/isStandardSyntaxDeclaration')
+var isCustomProperty = require('stylelint/lib/utils/isCustomProperty')
+var util = require('./util')
+var getProperty = util.getProperty
+var getOptions = util.getOptions
+var isSingleLineString = require("stylelint/lib/utils/isSingleLineString")
 
 function formatDecls (rule, indent, indentWidth, stylelint) {
-
+  const isSingleLine = isSingleLineString(rule)
   if (hasDecls(rule)) {
     rule.walkDecls(function (decl) {
-      var isCustomProp = /^--/.test(decl.prop)
       var isSassVal = /^\$/.test(decl.prop)
       var isIEHack = (/(\*|_)$/).test(decl.raws.before)
-
-      if (decl.prop && !isCustomProp && !isSassVal) {
+      if (decl.prop && !isCustomProperty(decl.prop) && !isSassVal) {
         decl.prop = decl.prop.toLowerCase()
       }
 
@@ -19,18 +23,7 @@ function formatDecls (rule, indent, indentWidth, stylelint) {
       }
 
       decl.raws.between = ': '
-
-      var declBefore
-      var prev = decl.prev()
-      if (prev && prev.type === 'comment') {
-        var nlCount = decl.raws.before.split('\n').length - 1
-        if (nlCount) {
-          declBefore = '\n'.repeat(nlCount) + indent + indentWidth
-        }
-      } else {
-        declBefore = '\n' + indent + indentWidth
-      }
-      decl.raws.before = declBefore
+      decl.raws.before = declarationEmptyLineBefore(stylelint, decl, indent, indentWidth, isSingleLine)
 
       if (getProperty(stylelint, 'declaration-colon-space-before')) {
         decl.raws.between = declarationColonSpaceBefore(stylelint, decl.raws.between)
@@ -63,6 +56,69 @@ function declarationColonSpaceAfter (stylelint, between) {
     default:
       return between
   }
+}
+
+
+function declarationEmptyLineBefore (stylelint, decl, indent, indentWidth, isSingleLine) {
+  var ignore = false
+  var prev = decl.prev()
+  var declBefore
+  if (getProperty(stylelint, 'declaration-empty-line-before')) {
+
+    var declarationEmptyLineBeforeRule = getProperty(stylelint, 'declaration-empty-line-before')
+    var exceptOptions = getOptions(stylelint, 'declaration-empty-line-before', 'except') || []
+    var ignoreOptions = getOptions(stylelint, 'declaration-empty-line-before', 'ignore') || []
+
+    var expectEmptyLineBefore = declarationEmptyLineBeforeRule === "always"
+
+    if (ignoreOptions.indexOf('after-comment') !== -1 && prev && prev.type === 'comment') {
+      ignore = true
+    }
+
+    if (ignoreOptions.indexOf('after-declaration') !== -1 && prev && prev.prop && isStandardSyntaxDeclaration(prev) && !isCustomProperty(prev.prop)) {
+      ignore = true
+    }
+
+    if (ignoreOptions.indexOf('inside-single-line-block') !== -1 && isSingleLine) {
+      ignore = true
+    }
+
+    if (exceptOptions.indexOf('first-nested') !== -1 && decl === decl.parent.first) {
+      expectEmptyLineBefore = !expectEmptyLineBefore
+    }
+
+    if (exceptOptions.indexOf('after-comment') !== -1 && prev && prev.type === 'comment') {
+      expectEmptyLineBefore = !expectEmptyLineBefore
+    }
+
+    if (exceptOptions.indexOf('after-declaration') !== -1 && prev && prev.prop && isStandardSyntaxDeclaration(prev) && !isCustomProperty(prev.prop)) {
+      expectEmptyLineBefore = !expectEmptyLineBefore
+    }
+
+    var hasEmptyLineBefore = hasEmptyLine(decl.raws.before)
+
+    if (ignore || (expectEmptyLineBefore === hasEmptyLineBefore)) {
+      declBefore = decl.raws.before
+    } else if (decl.parent.type === 'root' && decl === decl.parent.first) {
+      declBefore = ''
+    } else {
+      if (!hasEmptyLineBefore) {
+        declBefore = '\n\n' + indent + indentWidth
+      } else {
+        declBefore = '\n' + indent + indentWidth
+      }
+    }
+  } else {
+    if (prev && prev.type === 'comment') {
+      var nlCount = decl.raws.before.split('\n').length - 1
+      if (nlCount) {
+        declBefore = '\n'.repeat(nlCount) + indent + indentWidth
+      }
+    } else {
+      declBefore = '\n' + indent + indentWidth
+    }
+  }
+  return declBefore
 }
 
 module.exports = formatDecls

--- a/test/stylelint/declaration-empty-line-before-always-except/.stylelintrc
+++ b/test/stylelint/declaration-empty-line-before-always-except/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "declaration-empty-line-before": ["always", { except: ["after-comment", "after-declaration", "first-nested"] }]
+  }
+}

--- a/test/stylelint/declaration-empty-line-before-always-except/declaration-empty-line-before-always-except.css
+++ b/test/stylelint/declaration-empty-line-before-always-except/declaration-empty-line-before-always-except.css
@@ -1,0 +1,13 @@
+a {
+  /* comment */
+
+  top: 5px;
+
+}
+
+a {
+
+  bottom: 15px;
+
+  top: 5px;
+}

--- a/test/stylelint/declaration-empty-line-before-always-except/declaration-empty-line-before-always-except.out.css
+++ b/test/stylelint/declaration-empty-line-before-always-except/declaration-empty-line-before-always-except.out.css
@@ -1,0 +1,9 @@
+a {
+  /* comment */
+  top: 5px;
+}
+
+a {
+  bottom: 15px;
+  top: 5px;
+}

--- a/test/stylelint/declaration-empty-line-before-always-ignore/.stylelintrc
+++ b/test/stylelint/declaration-empty-line-before-always-ignore/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "declaration-empty-line-before": ["always", { ignore: ["after-comment", "after-declaration", "inside-single-line-block"] }]
+  }
+}

--- a/test/stylelint/declaration-empty-line-before-always-ignore/declaration-empty-line-before-always-ignore.css
+++ b/test/stylelint/declaration-empty-line-before-always-ignore/declaration-empty-line-before-always-ignore.css
@@ -1,0 +1,29 @@
+a {
+  /* comment */
+  top: 5px;
+}
+
+a {
+
+  bottom: 15px;
+  top: 15px;
+}
+
+a {
+
+  bottom: 15px;
+
+  top: 15px;
+}
+
+a {
+
+  color: orange;
+  text-decoration: none;
+
+  bottom: 15px;
+  top: 15px;
+}
+
+/* this one doesn't work because we don't support block-closing-brace-newline-before */
+/* a { bottom: 15px; top: 5px; } */

--- a/test/stylelint/declaration-empty-line-before-always-ignore/declaration-empty-line-before-always-ignore.out.css
+++ b/test/stylelint/declaration-empty-line-before-always-ignore/declaration-empty-line-before-always-ignore.out.css
@@ -1,0 +1,29 @@
+a {
+  /* comment */
+  top: 5px;
+}
+
+a {
+
+  bottom: 15px;
+  top: 15px;
+}
+
+a {
+
+  bottom: 15px;
+
+  top: 15px;
+}
+
+a {
+
+  color: orange;
+  text-decoration: none;
+
+  bottom: 15px;
+  top: 15px;
+}
+
+/* this one doesn't work because we don't support block-closing-brace-newline-before */
+/* a { bottom: 15px; top: 5px; } */

--- a/test/stylelint/declaration-empty-line-before-always/.stylelintrc
+++ b/test/stylelint/declaration-empty-line-before-always/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "declaration-empty-line-before": "always"
+  }
+}

--- a/test/stylelint/declaration-empty-line-before-always/declaration-empty-line-before-always.css
+++ b/test/stylelint/declaration-empty-line-before-always/declaration-empty-line-before-always.css
@@ -1,0 +1,8 @@
+a {
+  --foo: pink;
+  top: 5px;
+}
+a {
+  bottom: 15px;
+  top: 5px;
+}

--- a/test/stylelint/declaration-empty-line-before-always/declaration-empty-line-before-always.out.css
+++ b/test/stylelint/declaration-empty-line-before-always/declaration-empty-line-before-always.out.css
@@ -1,0 +1,13 @@
+a {
+
+  --foo: pink;
+
+  top: 5px;
+}
+
+a {
+
+  bottom: 15px;
+
+  top: 5px;
+}

--- a/test/stylelint/declaration-empty-line-before-never-except/.stylelintrc
+++ b/test/stylelint/declaration-empty-line-before-never-except/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "declaration-empty-line-before": ["never", { except: ["after-comment", "after-declaration", "first-nested"] }]
+  }
+}

--- a/test/stylelint/declaration-empty-line-before-never-except/declaration-empty-line-before-never-except.css
+++ b/test/stylelint/declaration-empty-line-before-never-except/declaration-empty-line-before-never-except.css
@@ -1,0 +1,9 @@
+a {
+  /* comment */
+  top: 5px;
+}
+
+a {
+  bottom: 15px;
+  top: 5px;
+}

--- a/test/stylelint/declaration-empty-line-before-never-except/declaration-empty-line-before-never-except.out.css
+++ b/test/stylelint/declaration-empty-line-before-never-except/declaration-empty-line-before-never-except.out.css
@@ -1,0 +1,12 @@
+a {
+  /* comment */
+
+  top: 5px;
+}
+
+a {
+
+  bottom: 15px;
+
+  top: 5px;
+}

--- a/test/stylelint/declaration-empty-line-before-never-ignore/.stylelintrc
+++ b/test/stylelint/declaration-empty-line-before-never-ignore/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "declaration-empty-line-before": ["never", { "ignore": ["after-comment", "after-declaration", "inside-single-line-block"] }]
+  }
+}

--- a/test/stylelint/declaration-empty-line-before-never-ignore/declaration-empty-line-before-never-ignore.css
+++ b/test/stylelint/declaration-empty-line-before-never-ignore/declaration-empty-line-before-never-ignore.css
@@ -1,0 +1,14 @@
+a {
+  /* comment */
+
+  bottom: 15px;
+}
+
+a {
+  bottom: 15px;
+
+  top: 15px;
+}
+
+
+/* a { bottom: 15px; top: 5px; } */

--- a/test/stylelint/declaration-empty-line-before-never-ignore/declaration-empty-line-before-never-ignore.out.css
+++ b/test/stylelint/declaration-empty-line-before-never-ignore/declaration-empty-line-before-never-ignore.out.css
@@ -1,0 +1,14 @@
+a {
+  /* comment */
+
+  bottom: 15px;
+}
+
+a {
+  bottom: 15px;
+
+  top: 15px;
+}
+
+
+/* a { bottom: 15px; top: 5px; } */

--- a/test/stylelint/declaration-empty-line-before-never/.stylelintrc
+++ b/test/stylelint/declaration-empty-line-before-never/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "declaration-empty-line-before": "never"
+  }
+}

--- a/test/stylelint/declaration-empty-line-before-never/declaration-empty-line-before-never.css
+++ b/test/stylelint/declaration-empty-line-before-never/declaration-empty-line-before-never.css
@@ -1,0 +1,11 @@
+a {
+  --foo: pink;
+
+  top: 5px;
+}
+a {
+
+  bottom: 15px;
+
+  top: 5px;
+}

--- a/test/stylelint/declaration-empty-line-before-never/declaration-empty-line-before-never.out.css
+++ b/test/stylelint/declaration-empty-line-before-never/declaration-empty-line-before-never.out.css
@@ -1,0 +1,9 @@
+a {
+  --foo: pink;
+  top: 5px;
+}
+
+a {
+  bottom: 15px;
+  top: 5px;
+}


### PR DESCRIPTION
see #256 

this supports everything except `ignore: ['inside-single-line-block']` which i think is related to `block-closing-brace-newline-before` support  (the code seems to work but a newline is always added before the closing brace). 
