### PR TITLE
at-rule-empty-line-before-always-except-inside-block

### DIFF
--- a/lib/formatAtRules.js
+++ b/lib/formatAtRules.js
@@ -173,6 +173,7 @@ function formatAtRules (root, params) {
       var ignore = false
       var ignoreOptions = getOptions(params.stylelint, 'at-rule-empty-line-before', 'ignore')
       if ( ignoreOptions && ((ignoreOptions.indexOf('all-nested') > -1 && isNested)
+        || (ignoreOptions.indexOf('inside-block') > -1 && isNested)
         || (ignoreOptions.indexOf('blockless-group') > -1 && isBlocklessGroup(prev, atrule))
         || (ignoreOptions.indexOf('blockless-after-same-name-blockless') > -1 && isBlocklessAfterSameNameBlockless(prev, atrule))
         || (ignoreOptions.indexOf('after-comment') > -1 && isAfterComment(prev))))
@@ -184,6 +185,7 @@ function formatAtRules (root, params) {
 
       var exceptOptions = getOptions(params.stylelint, 'at-rule-empty-line-before', 'except')
       if ( exceptOptions && ((exceptOptions.indexOf('all-nested') > -1 && isNested)
+        || (exceptOptions.indexOf('inside-block') > -1 && isNested)
         || (exceptOptions.indexOf('first-nested') > -1 && isFirstNested(prev, atrule, isNested))
         || (exceptOptions.indexOf('blockless-group') > -1 && isBlocklessGroup(prev, atrule))
         || (exceptOptions.indexOf('blockless-after-same-name-blockless') > -1 && isBlocklessAfterSameNameBlockless(prev, atrule))))

--- a/test/stylelint/at-rule-empty-line-before-always-except-inside-block/.stylelintrc
+++ b/test/stylelint/at-rule-empty-line-before-always-except-inside-block/.stylelintrc
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "at-rule-empty-line-before": ["always", {
+      except: ["inside-block"]
+    }]
+  }
+}

--- a/test/stylelint/at-rule-empty-line-before-always-except-inside-block/at-rule-empty-line-before-always-except-inside-block.css
+++ b/test/stylelint/at-rule-empty-line-before-always-except-inside-block/at-rule-empty-line-before-always-except-inside-block.css
@@ -1,0 +1,5 @@
+b {
+  color: pink;
+
+  @extend foo;
+}

--- a/test/stylelint/at-rule-empty-line-before-always-except-inside-block/at-rule-empty-line-before-always-except-inside-block.out.css
+++ b/test/stylelint/at-rule-empty-line-before-always-except-inside-block/at-rule-empty-line-before-always-except-inside-block.out.css
@@ -1,0 +1,4 @@
+b {
+  color: pink;
+  @extend foo;
+}


### PR DESCRIPTION
Addresses one part of #280

at-rule newline rules weren't respected for the `inline-block` exception, which serves as the replacement to `all-nested`, deprecated in [stylelint 7.8.0](https://stylelint.io/CHANGELOG/#780).

This PR allows stylefmt to respect both forms of the option.