### PR TITLE
Do not format values with slash on custom lostgrid properties

### DIFF
--- a/lib/formatValues.js
+++ b/lib/formatValues.js
@@ -2,13 +2,15 @@ var formatTransforms = require('./formatTransforms')
 var formatColors = require('./formatColors')
 var formatZeros = require('./formatZeros')
 var formatShorthand = require('./formatShorthand')
-var getProperty =  require('./util').getProperty
+var getProperty = require('./util').getProperty
 
 function formatvalues (decl, stylelint) {
   var isDataUrl = /data:.+\/(.+);base64,(.*)/.test(decl.value)
   var isVarNotation = /var\s*\(.*\)/.test(decl.value)
   var isString = /^("|').*("|')$/.test(decl.value)
   var isFunctionCall = /\w+\(.+\)/.test(decl.value)
+  // Lost grid custom properties http://lostgrid.org/
+  var isLostGridSubsetProp = (['lost-column', 'lost-row'].indexOf(decl.prop) > -1)
 
   if (decl.raws.value) {
     decl.raws.value.raw = decl.raws.value.raw.trim()
@@ -49,8 +51,8 @@ function formatvalues (decl, stylelint) {
   if (!isFunctionCall) {
     // format math operators before `$` or `(`.
     decl.value = decl.value.replace(/(?!^)[+\-*%](?=\$|\()/g, ' $& ')
-    // don't format "/" from a "font" shorthand property.
-    if (decl.prop !== 'font') {
+    // don't format "/" from a "font" shorthand property and from the lost grid
+    if (decl.prop !== 'font' && !isLostGridSubsetProp) {
       decl.value = decl.value.replace(/\/(?=\$|\(|\d)/g, ' $& ')
     }
     // format "-" if it is between numbers
@@ -68,11 +70,10 @@ function formatvalues (decl, stylelint) {
   decl.value = formatTransforms(decl.value)
 
   if (decl.important) {
-    decl.raws.important = " !important"
+    decl.raws.important = ' !important'
   }
 
   return decl
 }
-
 
 module.exports = formatvalues


### PR DESCRIPTION
This is not really PR but feature question with code example in form of PR to outline the problem.

I'm using [lostgrid](http://lostgrid.org/) framework for defining grids. And some of its properties exactly `lost-column` and `lost-row` can have a slash separated values like so:

```css
div {
  lost-column: 1/3;
}
```

And when it processed through the stylefmt the value becomes space separated `lost-column: 1 / 3;` which is not valid value for lostgrid.

I'm not sure if it's really a concern for stylefmt to take care of not standard properties, or what would be the best approach to make it work if there is any.

Thanks.
