### PR TITLE
Pass the stylelint config to formatDecls when invoking it

### DIFF
--- a/lib/formatAtRules.js
+++ b/lib/formatAtRules.js
@@ -33,7 +33,7 @@ function formatAtRules (root, params) {
     var isNested = atrule.parent !== root
     var origAtRuleBefore = atrule.raws.before
 
-    formatDecls(atrule, indentation, indentWidth)
+    formatDecls(atrule, indentation, indentWidth, stylelint)
     if (index === 0 && parentType === 'root') {
       atruleBefore = ''
     } else {
@@ -89,17 +89,17 @@ function formatAtRules (root, params) {
     }
 
     if (atrule.name === 'if' || atrule.name === 'else') {
-      formatDecls(atrule, indentation, indentWidth)
+      formatDecls(atrule, indentation, indentWidth, stylelint)
     }
 
     if (atrule.name === 'font-face') {
       atrule.raws.afterName = ''
-      formatDecls(atrule, indentation, indentWidth)
+      formatDecls(atrule, indentation, indentWidth, stylelint)
     }
 
     if (atrule.name === 'mixin') {
       atrule.params = atrule.params.replace(/(^[\w|-]+)\s*\(/, "$1(")
-      formatDecls(atrule, indentation, indentWidth)
+      formatDecls(atrule, indentation, indentWidth, stylelint)
     }
 
     if (atrule.name === 'extend' ||

--- a/lib/formatRules.js
+++ b/lib/formatRules.js
@@ -65,7 +65,7 @@ function formatRules (root, params) {
 
     rule.walkAtRules(function (rule) {
       var indentation = getIndent(rule, indentWidth)
-      formatDecls(rule, indentation, indentWidth)
+      formatDecls(rule, indentation, indentWidth, stylelint)
     })
   })
 


### PR DESCRIPTION
Some calls to `formatDecls` were missing the `stylelint` parameter. This fixes #256 