### PR TITLE
Simplify and fix repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
   "bin": {
     "stylefmt": "bin/cli.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/morishitter/stylefmt/git"
-  },
+  "repository": "morishitter/stylefmt",
   "engines": {
     "node": ">=4.2.0"
   },


### PR DESCRIPTION
Currently if you would use command `npm repo stylefmt`, it will lead you to the https://github.com/morishitter/stylefmt/git. Which is incorrect.

This commit also simplifies the definition of the `repository` property