### PR TITLE
Partial fix https://github.com/morishitter/stylefmt/issues/86

### DIFF
--- a/lib/formatDecls.js
+++ b/lib/formatDecls.js
@@ -22,7 +22,11 @@ function formatDecls (rule, indent, indentWidth, stylelint) {
         decl.prop = decl.raws.before.trim().replace(/\n/g, '') + decl.prop
       }
 
-      decl.raws.between = ': '
+      if (decl.raws.between.indexOf('\n') !== -1) {
+        decl.raws.between = ':\n' + indent + indentWidth.repeat(2)
+      } else {
+        decl.raws.between = ': '
+      }
       decl.raws.before = declarationEmptyLineBefore(stylelint, decl, indent, indentWidth, isSingleLine)
 
       if (getProperty(stylelint, 'declaration-colon-space-before')) {
@@ -33,7 +37,7 @@ function formatDecls (rule, indent, indentWidth, stylelint) {
         decl.raws.between = declarationColonSpaceAfter(stylelint, decl.raws.between)
       }
 
-      formatValues(decl, stylelint)
+      formatValues(stylelint, decl, indent, indentWidth)
     })
   }
 

--- a/lib/formatValues.js
+++ b/lib/formatValues.js
@@ -4,7 +4,7 @@ var formatZeros = require('./formatZeros')
 var formatShorthand = require('./formatShorthand')
 var getProperty =  require('./util').getProperty
 
-function formatvalues (decl, stylelint) {
+function formatValues (stylelint, decl, indent, indentWidth) {
   var isDataUrl = /data:.+\/(.+);base64,(.*)/.test(decl.value)
   var isVarNotation = /var\s*\(.*\)/.test(decl.value)
   var isString = /^("|').*("|')$/.test(decl.value)
@@ -15,7 +15,11 @@ function formatvalues (decl, stylelint) {
   }
 
   if (!isString) {
-    decl.value = decl.value.trim().replace(/\s+/g, ' ')
+    decl.value = decl.value.trim().replace(/[^\S\n]+/g, ' ')
+    decl.value = decl.value.replace(/\n /g, '\n')
+    decl.value = decl.value.replace(/ \n/g, '\n')
+    decl.value = decl.value.replace(
+      /\n+/g, '\n' + indent + indentWidth.repeat(2))
   }
 
   switch (getProperty(stylelint, 'string-quotes')) {
@@ -37,8 +41,8 @@ function formatvalues (decl, stylelint) {
   }
 
   if (!isDataUrl) {
-    // Remove spaces before commas and keep only one space after.
-    decl.value = decl.value.trim().replace(/(\s+)?,(\s)*/g, ', ')
+    // Remove spaces before commas.
+    decl.value = decl.value.trim().replace(/(\s+)?,/g, ',')
   }
 
   if (isVarNotation) {
@@ -75,4 +79,4 @@ function formatvalues (decl, stylelint) {
 }
 
 
-module.exports = formatvalues
+module.exports = formatValues


### PR DESCRIPTION
Now when css contain new lines in decl value, stylefmt only format and collaps spaces, but keep new lines

Example:
```
.test {
  font: 'italic small-caps bold 12px arial, sans-serif',14px;

  background: red,
   green , yellow;
  background-color:
    rgba(0, 0, 0, .4),

       rgba(0, 0, 0, 0);
}
```

And there result is:
```
.test {
  font: 'italic small-caps bold 12px arial, sans-serif',14px;
  background: red,
    green, yellow;
  background-color:
    rgba(0, 0, 0, .4),
    rgba(0, 0, 0, 0);
}
```