### PR TITLE
Swap chalk for turbocolor.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -162,28 +162,28 @@ function isCss (filePath) {
 
 function handleDiff (file, original, formatted) {
   var diff
-  var chalk = require('chalk')
+  var tc = require('turbocolor')
 
   if (original === formatted) {
     diff = 'There is no difference with the original file.'
   }
 
-  if (chalk.supportsColor) {
-    file = chalk.blue(file)
+  if (tc.enabled) {
+    file = tc.blue(file)
     if(diff) {
-      diff = chalk.gray(diff)
+      diff = tc.gray(diff)
     } else {
       var JsDiff = require('diff')
       diff = JsDiff.createPatch(file, original, formatted)
       diff = diff.split('\n').splice(4).map(function (line) {
         if (line[0] === '+') {
-          line = chalk.green(line)
+          line = tc.green(line)
         } else if (line[0] === '-') {
-          line = chalk.red(line)
+          line = tc.red(line)
         } else if (line.match(/^@@\s+.+?\s+@@/) || '\\ No newline at end of file' === line) {
           line = ''
         }
-        return chalk.gray(line)
+        return tc.gray(line)
       })
       diff = diff.join('\n').trim()
     }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Masaaki Morishita",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^1.1.3",
+    "turbocolor": "^2.3.0",
     "css-color-list": "^0.0.1",
     "diff": "^3.2.0",
     "editorconfig": "^0.13.2",


### PR DESCRIPTION
Hey @morishitter! 

This swaps chalk for [Turbocolor](https://github.com/jorgebucaran/turbocolor).

It will give you a performance boost as turbocolor loads **_>20x_** faster and applies styles **_>18x_** faster than chalk for the same API (see [benchmarks](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks)). 

<pre>
# Load Time
chalk: 15.190ms
<b>turbocolor: 0.777ms</b>

# All Colors
chalk × 8,729 ops/sec
<b>turbocolor × 158,383 ops/sec</b>

# Chained Colors
chalk × 1,838 ops/sec
<b>turbocolor × 39,830 ops/sec</b>

# Nested Colors
chalk × 4,049 ops/sec
<b>turbocolor × 59,833 ops/sec</b>
</pre>

Let me know if this is acceptable to you or if you want to refactor anything. 

Cheers!