### PR TITLE
Swap minimist for getopts for more perf gains!

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,8 +6,8 @@ var stdin = require('stdin')
 var pkg = require('../package.json')
 var stylefmt = require('../')
 
-var minimist = require('minimist')
-var argv = minimist(process.argv.slice(2), {
+var getopts = require('getopts')
+var argv = getopts(process.argv.slice(2), {
   boolean: [
     'help',
     'version'

--- a/package.json
+++ b/package.json
@@ -30,19 +30,19 @@
   "author": "Masaaki Morishita",
   "license": "MIT",
   "dependencies": {
-    "turbocolor": "^2.3.0",
     "css-color-list": "^0.0.1",
     "diff": "^3.2.0",
     "editorconfig": "^0.13.2",
+    "getopts": "^2.1.1",
     "globby": "^6.1.0",
-    "minimist": "^1.2.0",
     "postcss": "^6.0.1",
     "postcss-scss": "^1.0.0",
     "postcss-sorting": "^2.1.0",
     "postcss-value-parser": "^3.3.0",
     "stdin": "^0.0.1",
     "stylelint": "^7.10.1",
-    "stylelint-order": "^0.4.4"
+    "stylelint-order": "^0.4.4",
+    "turbocolor": "^2.3.0"
   },
   "devDependencies": {
     "each-series": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -733,6 +733,10 @@ get-stdin@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
+getopts@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.1.1.tgz#330d29c59d0a1b4ec7e0e4e43a8d1dd42ccee565"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -1957,6 +1961,10 @@ trim-newlines@^1.0.0:
 tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
+
+turbocolor@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/turbocolor/-/turbocolor-2.3.0.tgz#9b720e38c6f907add42d9315aa18cf797d79f148"
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
Hi @morishitter! This PR swaps minimist for [getopts](https://github.com/jorgebucaran/getopts) for more perf gains (full benchmarks [here](https://github.com/jorgebucaran/getopts/tree/master/bench)).

<pre>
mri × 374,999 ops/sec
yargs × 32,370 ops/sec
<b>getopts × 1,495,165 ops/sec</b>
minimist × 283,031 ops/sec
</pre>

Getopts has essentially the same API as minimist, so this is effectively a "drop-in" replacement. I think minimist is a great package, but also too difficult to contribute to (34 open issues and 26 pull requests, but no updates since 2015).

Let me know if this looks good to you. Cheers!