### PR TITLE
Added support for Regex to determinate a data url

### DIFF
--- a/lib/formatValues.js
+++ b/lib/formatValues.js
@@ -5,7 +5,7 @@ var formatShorthand = require('./formatShorthand')
 var getProperty =  require('./util').getProperty
 
 function formatvalues (decl, stylelint) {
-  var isDataUrl = /data:.+\/(.+);base64,(.*)/.test(decl.value)
+  var isDataUrl = /data:.+\/(.+),(.*)/.test(decl.value)
   var isVarNotation = /var\s*\(.*\)/.test(decl.value)
   var isString = /^("|').*("|')$/.test(decl.value)
   var isFunctionCall = /\w+\(.+\)/.test(decl.value)


### PR DESCRIPTION
There is currently a problem with SVGs in data-urls.

```css
background-image: url('data:image/svg+xml;utf8,<svg ...> ... </svg>');
```
After formatting stylefmt return this:
```css
background-image: url('data:image/svg+xml;utf8, <svg ...> ... </svg>');
```
A space is added after the comma, but this is an incorrect syntax (see [RFC2397](https://tools.ietf.org/html/rfc2397#section-3)).

The reason for this incorrect syntax is that stylefmt expects data-urls encoded as base64, but this is still not required by the rfc.  

Therefore I removed the base64 part in the regex to allow data ASCII data as well. The _data:_ must be enough as indicator.



Of course we can match the base64 in the regex but this only a test and therefor I reduced it as far as possible.
Alternative would be:
```regex
/data:.+\/(.+)(;base64)?,(.*)/
```